### PR TITLE
Update version of Gofor linux  to 1.11.1

### DIFF
--- a/modules/runtimes/PrefabGolang.py
+++ b/modules/runtimes/PrefabGolang.py
@@ -62,7 +62,7 @@ class PrefabGolang(app):
                 downl = "https://storage.googleapis.com/golang/go1.8.7.darwin-amd64.tar.gz"
         elif "ubuntu" in self.prefab.platformtype.platformtypes:
             if old is False:
-                downl = "https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz"
+                downl = "https://storage.googleapis.com/golang/go1.11.1.linux-amd64.tar.gz"
             else:
                 downl = "https://storage.googleapis.com/golang/go1.8.7.linux-amd64.tar.gz"
         else:


### PR DESCRIPTION
#### What this PR resolves:


#### Changes proposed in this PR:
Upgrade go version in prefab to version 1.11.1

**Version**: 

**Fixes**:  #33 
